### PR TITLE
Add exclude column for data tables

### DIFF
--- a/CRM/Sqltasks/Action.php
+++ b/CRM/Sqltasks/Action.php
@@ -266,6 +266,10 @@ abstract class CRM_Sqltasks_Action {
     $this->has_executed = TRUE;
   }
 
+  protected function _columnExists($table, $column) {
+    return CRM_Core_DAO::singleValueQuery("SHOW COLUMNS FROM `{$table}` LIKE '{$column}';");
+  }
+
   /**
    * check if this process has "done anything"
    */

--- a/CRM/Sqltasks/Action/APICall.php
+++ b/CRM/Sqltasks/Action/APICall.php
@@ -160,7 +160,12 @@ class CRM_Sqltasks_Action_APICall extends CRM_Sqltasks_Action {
     $more_fails_counter = 0;
 
     $data_table = $this->getDataTable();
-    $query = CRM_Core_DAO::executeQuery("SELECT * FROM {$data_table}");
+    $excludeSql = '';
+    if ($this->_columnExists($data_table, 'exclude')) {
+      $excludeSql = 'WHERE (exclude IS NULL OR exclude != 1)';
+      $this->log('Column "exclude" exists, might skip some rows');
+    }
+    $query = CRM_Core_DAO::executeQuery("SELECT * FROM {$data_table} {$excludeSql}");
     while ($query->fetch()) {
       $this->setHasExecuted();
       $parameters = $this->fillParameters($parameter_specs, $query);

--- a/CRM/Sqltasks/Action/CSVExport.php
+++ b/CRM/Sqltasks/Action/CSVExport.php
@@ -307,7 +307,12 @@ class CRM_Sqltasks_Action_CSVExport extends CRM_Sqltasks_Action {
     $count = 0;
     $column_list = implode(',', $columns);
     // error_log("SELECT {$column_list} FROM {$export_table}");
-    $query = CRM_Core_DAO::executeQuery("SELECT {$column_list} FROM {$export_table}");
+    $excludeSql = '';
+    if ($this->_columnExists($export_table, 'exclude')) {
+      $excludeSql = 'WHERE (exclude IS NULL OR exclude != 1)';
+      $this->log('Column "exclude" exists, might skip some rows');
+    }
+    $query = CRM_Core_DAO::executeQuery("SELECT {$column_list} FROM {$export_table} {$excludeSql}");
     while ($query->fetch()) {
       $this->setHasExecuted();
       $record = array();


### PR DESCRIPTION
This adds support for an "exclude" column in data tables. When the column is present in a table and the value is 1, the row is skipped within the action. For the SegmentationAssign action, affected rows are added to the exclusion test table.

Fixes #22