### PR TITLE
Don't set executed if exported segments are empty

### DIFF
--- a/CRM/Sqltasks/Action/ResultHandler.php
+++ b/CRM/Sqltasks/Action/ResultHandler.php
@@ -205,6 +205,7 @@ class CRM_Sqltasks_Action_ResultHandler extends CRM_Sqltasks_Action {
       $should_run = $this->shouldErrorHandlerRun($actions);
     }
     if (!$should_run) {
+      $this->log("Skipping Success Handler, actions didn't do anything");
       return;
     }
 


### PR DESCRIPTION
Skip the success handler if the SegmentationExport action exported an empty file.

The empty (header-only) file is still exported to preserve backwards-compatibility.