### PR TITLE
GP-1483: Don't create activity if contact table is empty

### DIFF
--- a/CRM/Sqltasks/Action/CreateActivity.php
+++ b/CRM/Sqltasks/Action/CreateActivity.php
@@ -138,6 +138,9 @@ class CRM_Sqltasks_Action_CreateActivity extends CRM_Sqltasks_Action_ContactSet 
     if ($entries_exist) {
       $this->setHasExecuted();
     }
+    else {
+      return;
+    }
 
     // create activity first
     $activity_data = array(


### PR DESCRIPTION
We don't want to create empty mass activities whenever a task with an empty contact table is executed.