### PR TITLE
Sanitize file name when exporting job

### DIFF
--- a/CRM/Sqltasks/Page/Manager.php
+++ b/CRM/Sqltasks/Page/Manager.php
@@ -133,7 +133,7 @@ class CRM_Sqltasks_Page_Manager extends CRM_Core_Page {
       $task = CRM_Sqltasks_Task::getTask($export_id);
       $config = $task->exportConfiguration();
       CRM_Utils_System::download(
-        $task->getAttribute('name') . '.sqltask',
+        preg_replace('/[^A-Za-z0-9_\- ]/', '', $task->getAttribute('name')) . '.sqltask',
         'application/json',
         $config);
     }


### PR DESCRIPTION
Certain characters like double quotes can cause exports to fail because of an invalid HTTP header. This filters out all characters that are potentially problematic in file names.

Fixes #31