### PR TITLE
GP-1940: Track exclusions via activity, other improvements

### DIFF
--- a/templates/CRM/Sqltasks/Action/CreateActivity.tpl
+++ b/templates/CRM/Sqltasks/Action/CreateActivity.tpl
@@ -81,4 +81,40 @@
     <div class="clear"></div>
   </div>
 
+  <div class="crm-section">
+    <div class="label">{$form.activity_source_record_id.label} <a onclick='CRM.help("{ts domain="de.systopia.sqltasks"}Tokens{/ts}", {literal}{"id":"id-activity-tokens","file":"CRM\/Sqltasks\/Action\/CreateActivity"}{/literal}); return false;' href="#" title="{ts domain="de.systopia.sqltasks"}Help{/ts}" class="helpicon">&nbsp;</a></div>
+    <div class="content">{$form.activity_source_record_id.html}</div>
+    <div class="clear"></div>
+  </div>
+
+  <div class="crm-section">
+    <div class="label">{$form.activity_medium_id.label}</div>
+    <div class="content">{$form.activity_medium_id.html}</div>
+    <div class="clear"></div>
+  </div>
+
+  <div class="crm-section">
+    <div class="label">{$form.activity_engagement_level.label}</div>
+    <div class="content">{$form.activity_engagement_level.html}</div>
+    <div class="clear"></div>
+  </div>
+
+  <div class="crm-section">
+    <div class="label">{$form.activity_location.label} <a onclick='CRM.help("{ts domain="de.systopia.sqltasks"}Tokens{/ts}", {literal}{"id":"id-activity-tokens","file":"CRM\/Sqltasks\/Action\/CreateActivity"}{/literal}); return false;' href="#" title="{ts domain="de.systopia.sqltasks"}Help{/ts}" class="helpicon">&nbsp;</a></div>
+    <div class="content">{$form.activity_location.html}</div>
+    <div class="clear"></div>
+  </div>
+
+  <div class="crm-section">
+    <div class="label">{$form.activity_duration.label} <a onclick='CRM.help("{ts domain="de.systopia.sqltasks"}Tokens{/ts}", {literal}{"id":"id-activity-tokens","file":"CRM\/Sqltasks\/Action\/CreateActivity"}{/literal}); return false;' href="#" title="{ts domain="de.systopia.sqltasks"}Help{/ts}" class="helpicon">&nbsp;</a></div>
+    <div class="content">{$form.activity_duration.html} <span class="description">{ts}minutes{/ts}</span></div>
+    <div class="clear"></div>
+  </div>
+
+  <div class="crm-section">
+    <div class="label">{$form.activity_priority_id.label}</div>
+    <div class="content">{$form.activity_priority_id.html}</div>
+    <div class="clear"></div>
+  </div>
+
 </div>

--- a/templates/CRM/Sqltasks/Action/SegmentationExport.tpl
+++ b/templates/CRM/Sqltasks/Action/SegmentationExport.tpl
@@ -47,6 +47,12 @@
   </div>
 
   <div class="crm-section">
+    <div class="label">{$form.segmentation_export_discard_empty.label}</div>
+    <div class="content">{$form.segmentation_export_discard_empty.html}</div>
+    <div class="clear"></div>
+  </div>
+
+  <div class="crm-section">
     <div class="label">{$form.segmentation_export_exporter.label}</div>
     <div class="content">{$form.segmentation_export_exporter.html}</div>
     <div class="clear"></div>

--- a/templates/CRM/Sqltasks/Page/Runner.tpl
+++ b/templates/CRM/Sqltasks/Page/Runner.tpl
@@ -46,6 +46,9 @@ div.task-results {
   <!-- <span class="crm-button-icon ui-icon-check"></span> -->
   <div onClick="location.replace('{crmURL p='civicrm/sqltasks/run' q="tid=$task_id"}');" title="{ts}Run again{/ts}">{ts}Run again{/ts}</div>
 </span>
+<span class="crm-button crm-icon-button">
+  <div onClick="location.replace('{crmURL p='civicrm/sqltasks/configure' q="tid=$task_id"}');" title="{ts}Configure task{/ts}">{ts}Configure task{/ts}</div>
+</span>
 
 
 {* API CALL *}


### PR DESCRIPTION
In order to keep track of contacts in exclusion segments, this change creates an activity of type "Exclusion Record" when there's a matching row in civicrm_segmentation_exclude.

This also includes minor improvements to the "Create Activity" and "Segmentation Export" action:
- For "Create Activity", all contact fields now use an entityRef form element, and the "Campaign" field allows filtering. Additionally, a number of missing fields like medium and source_record_id were added.
- For "Segmentation Export", a "Discard empty file?" option was added. This option is triggered if no contacts are found in the selected campaign/segment.

Related to https://github.com/systopia/de.systopia.segmentation/pull/12