### PR TITLE
Use monospace font for code, style improvements

### DIFF
--- a/CRM/Sqltasks/Action/APICall.php
+++ b/CRM/Sqltasks/Action/APICall.php
@@ -48,6 +48,7 @@ class CRM_Sqltasks_Action_APICall extends CRM_Sqltasks_Action {
       'text',
       $this->getID() . '_table',
       E::ts('Data Table'),
+      ['style' => 'font-family: monospace, monospace !important'],
       TRUE
     );
 
@@ -55,6 +56,7 @@ class CRM_Sqltasks_Action_APICall extends CRM_Sqltasks_Action {
       'text',
       $this->getID() . '_entity',
       E::ts('Entity'),
+      ['style' => 'font-family: monospace, monospace !important'],
       TRUE
     );
 
@@ -62,6 +64,7 @@ class CRM_Sqltasks_Action_APICall extends CRM_Sqltasks_Action {
       'text',
       $this->getID() . '_action',
       E::ts('Action'),
+      ['style' => 'font-family: monospace, monospace !important'],
       TRUE
     );
 
@@ -69,7 +72,11 @@ class CRM_Sqltasks_Action_APICall extends CRM_Sqltasks_Action {
       'textarea',
       $this->getID() . '_parameters',
       E::ts('Parameters'),
-      array('rows' => 8, 'cols' => 40),
+      [
+        'rows' => 8,
+        'cols' => 40,
+        'style' => 'font-family: monospace, monospace !important',
+      ],
       FALSE
     );
   }

--- a/CRM/Sqltasks/Action/CSVExport.php
+++ b/CRM/Sqltasks/Action/CSVExport.php
@@ -46,6 +46,7 @@ class CRM_Sqltasks_Action_CSVExport extends CRM_Sqltasks_Action {
       'text',
       $this->getID() . '_table',
       E::ts('Export Table'),
+      ['style' => 'font-family: monospace, monospace !important'],
       TRUE
     );
 
@@ -67,7 +68,7 @@ class CRM_Sqltasks_Action_CSVExport extends CRM_Sqltasks_Action {
       'textarea',
       $this->getID() . '_headers',
       E::ts('Columns'),
-      array('rows' => 8, 'cols' => 40),
+      array('rows' => 8, 'cols' => 40, 'style' => 'font-family: monospace, monospace !important'),
       FALSE
     );
 
@@ -82,14 +83,14 @@ class CRM_Sqltasks_Action_CSVExport extends CRM_Sqltasks_Action {
       'text',
       $this->getID() . '_filename',
       E::ts('File Name'),
-      array('class' => 'huge')
+      array('class' => 'huge', 'style' => 'font-family: monospace, monospace !important')
     );
 
     $form->add(
       'text',
       $this->getID() . '_path',
       E::ts('File Path'),
-      array('class' => 'huge')
+      array('class' => 'huge', 'style' => 'font-family: monospace, monospace !important')
     );
 
     $form->add(
@@ -110,7 +111,7 @@ class CRM_Sqltasks_Action_CSVExport extends CRM_Sqltasks_Action {
       'text',
       $this->getID() . '_upload',
       E::ts('Upload to'),
-      array('class' => 'huge')
+      array('class' => 'huge', 'style' => 'font-family: monospace, monospace !important')
     );
 
     $form->add(

--- a/CRM/Sqltasks/Action/ContactSet.php
+++ b/CRM/Sqltasks/Action/ContactSet.php
@@ -30,6 +30,7 @@ abstract class CRM_Sqltasks_Action_ContactSet extends CRM_Sqltasks_Action {
       'text',
       $this->getID() . '_contact_table',
       E::ts('Contact Table (<code>contact_id</code>)'),
+      ['style' => 'font-family: monospace, monospace !important'],
       TRUE
     );
   }

--- a/CRM/Sqltasks/Action/CreateActivity.php
+++ b/CRM/Sqltasks/Action/CreateActivity.php
@@ -72,14 +72,14 @@ class CRM_Sqltasks_Action_CreateActivity extends CRM_Sqltasks_Action_ContactSet 
       'text',
       $this->getID() . '_subject',
       E::ts('Subject'),
-      array('class' => 'huge')
+      array('class' => 'huge', 'style' => 'font-family: monospace, monospace !important')
     );
 
     $form->add(
       'textarea',
       $this->getID() . '_details',
       E::ts('Details'),
-      array('rows' => 4, 'cols' => 60),
+      array('rows' => 4, 'cols' => 60, 'style' => 'font-family: monospace, monospace !important'),
       FALSE
     );
 
@@ -87,6 +87,7 @@ class CRM_Sqltasks_Action_CreateActivity extends CRM_Sqltasks_Action_ContactSet 
       'text',
       $this->getID() . '_activity_date_time',
       E::ts('Timestamp'),
+      ['style' => 'font-family: monospace, monospace !important'],
       FALSE
     );
 
@@ -122,7 +123,8 @@ class CRM_Sqltasks_Action_CreateActivity extends CRM_Sqltasks_Action_ContactSet 
     $form->add(
       'text',
       $this->getID() . '_source_record_id',
-      E::ts('Source Record ID')
+      E::ts('Source Record ID'),
+      ['style' => 'font-family: monospace, monospace !important']
     );
 
     $form->add(
@@ -142,13 +144,15 @@ class CRM_Sqltasks_Action_CreateActivity extends CRM_Sqltasks_Action_ContactSet 
     $form->add(
       'text',
       $this->getID() . '_location',
-      E::ts('Location')
+      E::ts('Location'),
+      ['style' => 'font-family: monospace, monospace !important']
     );
 
     $form->add(
       'text',
       $this->getID() . '_duration',
-      E::ts('Duration')
+      E::ts('Duration'),
+      ['style' => 'font-family: monospace, monospace !important']
     );
   }
 

--- a/CRM/Sqltasks/Action/ResultHandler.php
+++ b/CRM/Sqltasks/Action/ResultHandler.php
@@ -86,7 +86,8 @@ class CRM_Sqltasks_Action_ResultHandler extends CRM_Sqltasks_Action {
     $form->add(
       'text',
       $this->getID() . '_table',
-      E::ts('User Error Table')
+      E::ts('User Error Table'),
+      ['style' => 'font-family: monospace, monospace !important']
     );
 
     $form->add(

--- a/CRM/Sqltasks/Form/Configure.php
+++ b/CRM/Sqltasks/Form/Configure.php
@@ -78,7 +78,7 @@ class CRM_Sqltasks_Form_Configure extends CRM_Core_Form {
       'main_sql',
       E::ts('Main Script (SQL)'),
       array('rows' => 8,
-            'cols' => 60,
+            'style' => 'font-family: monospace, monospace !important; width: 95%; min-width: 240px;',
       ),
       FALSE
     );
@@ -88,7 +88,7 @@ class CRM_Sqltasks_Form_Configure extends CRM_Core_Form {
       'post_sql',
       E::ts('Cleanup Script (SQL)'),
       array('rows' => 8,
-            'cols' => 60,
+            'style' => 'font-family: monospace, monospace !important; width: 95%; min-width: 240px;',
       ),
       FALSE
     );

--- a/templates/CRM/Sqltasks/Action/CreateActivity.tpl
+++ b/templates/CRM/Sqltasks/Action/CreateActivity.tpl
@@ -33,6 +33,8 @@
 
   <hr/>
 
+  <div class="spacer"></div>
+
   <div class="crm-section">
     <div class="label">{$form.activity_activity_type_id.label}</div>
     <div class="content">{$form.activity_activity_type_id.html}</div>

--- a/templates/CRM/Sqltasks/Form/Configure.tpl
+++ b/templates/CRM/Sqltasks/Form/Configure.tpl
@@ -18,19 +18,21 @@
 
   <h3>{ts}Basic Information{/ts}</h3>
 
-  <div class="crm-section">
+  <div class="spacer"></div>
+
+  <div class="crm-section form-item">
     <div class="label">{$form.name.label}</div>
     <div class="content">{$form.name.html}</div>
     <div class="clear"></div>
   </div>
 
-  <div class="crm-section">
+  <div class="crm-section form-item">
     <div class="label">{$form.description.label}&nbsp;<a onclick='CRM.help("{ts domain="de.systopia.sqltasks"}Description{/ts}", {literal}{"id":"id-configure-description","file":"CRM\/Sqltasks\/Form\/Configure"}{/literal}); return false;' href="#" title="{ts domain="de.systopia.sqltasks"}Help{/ts}" class="helpicon">&nbsp;</a></div>
     <div class="content">{$form.description.html}</div>
     <div class="clear"></div>
   </div>
 
-  <div class="crm-section">
+  <div class="crm-section form-item">
     <div class="label">{$form.category.label}&nbsp;<a onclick='CRM.help("{ts domain="de.systopia.sqltasks"}Category{/ts}", {literal}{"id":"id-configure-category","file":"CRM\/Sqltasks\/Form\/Configure"}{/literal}); return false;' href="#" title="{ts domain="de.systopia.sqltasks"}Help{/ts}" class="helpicon">&nbsp;</a></div>
     <div class="content">{$form.category.html}</div>
     <div class="clear"></div>
@@ -38,19 +40,23 @@
 
   <h3>{ts}Queries{/ts}</h3>
 
-  <div class="crm-section">
+  <div class="spacer"></div>
+
+  <div class="crm-section form-item">
     <div class="label">{$form.main_sql.label}&nbsp;<a onclick='CRM.help("{ts domain="de.systopia.sqltasks"}Main Script{/ts}", {literal}{"id":"id-configure-main","file":"CRM\/Sqltasks\/Form\/Configure"}{/literal}); return false;' href="#" title="{ts domain="de.systopia.sqltasks"}Help{/ts}" class="helpicon">&nbsp;</a></div>
     <div class="content">{$form.main_sql.html}</div>
     <div class="clear"></div>
   </div>
 
-  <div class="crm-section">
+  <div class="crm-section form-item">
     <div class="label">{$form.post_sql.label}&nbsp;<a onclick='CRM.help("{ts domain="de.systopia.sqltasks"}Clean Up{/ts}", {literal}{"id":"id-configure-post","file":"CRM\/Sqltasks\/Form\/Configure"}{/literal}); return false;' href="#" title="{ts domain="de.systopia.sqltasks"}Help{/ts}" class="helpicon">&nbsp;</a></div>
     <div class="content">{$form.post_sql.html}</div>
     <div class="clear"></div>
   </div>
 
   <h3>{ts}Execution{/ts}</h3>
+
+  <div class="spacer"></div>
 
   <div class="crm-section">
     <div class="label">{$form.scheduled.label}</div>


### PR DESCRIPTION
This changes all input fields dealing with code, tokens or similar to use a monospace font.

It also includes minor style improvements, including changes to textarea sizes and a spacing fix for shoreditch.