### PR TITLE
Use lazy initialization for task overview sorter

### DIFF
--- a/js/sortTasks.js
+++ b/js/sortTasks.js
@@ -6,7 +6,8 @@ cj( document ).ready(function() {
         forceHelperSize: true,
         items: '.sorting-init',
         update: function (event, ui) {
-
+            sortable.find('tr').addClass('sorting-init');
+            sortable.sortable('refresh');
             var data = cj(this).sortable( "toArray");
 
             CRM.api3('Sqltask', 'sort', {

--- a/js/sortTasks.js
+++ b/js/sortTasks.js
@@ -1,9 +1,10 @@
 cj( document ).ready(function() {
 
-    cj( "#sortable-tasks" ).sortable({
+    var sortable = cj( "#sortable-tasks" ).sortable({
         placeholder: "ui-state-highlight",
         handle: '.handle',
         forceHelperSize: true,
+        items: '.sorting-init',
         update: function (event, ui) {
 
             var data = cj(this).sortable( "toArray");
@@ -18,6 +19,9 @@ cj( document ).ready(function() {
             });
 
         }
-        });
-    //cj( "#sortable-tasks" ).disableSelection();
+    });
+    sortable.find('tr').one('mouseenter', function() {
+        cj(this).addClass('sorting-init');
+        sortable.sortable('refresh');
+    });
 });


### PR DESCRIPTION
This changes the task overview drag-and-drop sorter (implemented via the jQuery UI Sortable widget) to lazily initialize the sorter for each row on mouseenter. This dramatically improves loading speed on installations with a large number of tasks.

Fixes #39