### PR TITLE
Fix duplicate key error during group or tag sync

### DIFF
--- a/CRM/Sqltasks/Action/SyncGroup.php
+++ b/CRM/Sqltasks/Action/SyncGroup.php
@@ -112,7 +112,7 @@ class CRM_Sqltasks_Action_SyncGroup extends CRM_Sqltasks_Action_ContactSet {
                                    FROM civicrm_group_contact
                                   WHERE group_id = {$group_id}) {$excludeSql})
         ON DUPLICATE KEY UPDATE
-          id = id");
+          civicrm_group_contact.id = civicrm_group_contact.id");
 
     // 2. update the ones that have been previously removed
     // 2.1. subscription history

--- a/CRM/Sqltasks/Action/SyncTag.php
+++ b/CRM/Sqltasks/Action/SyncTag.php
@@ -108,7 +108,7 @@ class CRM_Sqltasks_Action_SyncTag extends CRM_Sqltasks_Action_ContactSet {
         FROM {$contact_table}
         WHERE contact_id IS NOT NULL {$excludeSql})
         ON DUPLICATE KEY UPDATE
-          id = id");
+          civicrm_entity_tag.id = civicrm_entity_tag.id");
   }
 
   /**

--- a/CRM/Sqltasks/Action/SyncTag.php
+++ b/CRM/Sqltasks/Action/SyncTag.php
@@ -100,13 +100,15 @@ class CRM_Sqltasks_Action_SyncTag extends CRM_Sqltasks_Action_ContactSet {
 
     // then: add all missing contacts
     CRM_Core_DAO::executeQuery("
-      INSERT IGNORE INTO civicrm_entity_tag (entity_table, entity_id, tag_id)
+      INSERT INTO civicrm_entity_tag (entity_table, entity_id, tag_id)
         (SELECT
           '{$entity_table}'  AS entity_table,
           contact_id         AS entity_id,
           {$tag_id}          AS tag_id
         FROM {$contact_table}
-        WHERE contact_id IS NOT NULL {$excludeSql})");
+        WHERE contact_id IS NOT NULL {$excludeSql})
+        ON DUPLICATE KEY UPDATE
+          id = id");
   }
 
   /**
@@ -140,7 +142,7 @@ class CRM_Sqltasks_Action_SyncTag extends CRM_Sqltasks_Action_ContactSet {
 
     // then: add the new ones
     $tags2add = CRM_Core_DAO::executeQuery("
-      SELECT contact_id
+      SELECT DISTINCT contact_id
       FROM `{$contact_table}`
       LEFT JOIN civicrm_entity_tag et ON  et.entity_id = contact_id
                                       AND et.entity_table = '{$entity_table}'


### PR DESCRIPTION
This fixes various scenarios where tag or group sync can cause duplicate key errors, including cases where the data table contains duplicate contact IDs and where tag/group membership is changed
concurrently.

Error handling for duplicate keys is now performed via `ON DUPLICATE KEY` rather than `INSERT IGNORE` because the latter could potentially ignore other, unrelated database errors.

GP-1735