### PR TITLE
add downloadURL token in csv export task

### DIFF
--- a/sqltasks.php
+++ b/sqltasks.php
@@ -154,3 +154,30 @@ function sqltasks_civicrm_navigationMenu(&$menu) {
   ));
   _sqltasks_civix_navigationMenu($menu);
 }
+
+/**
+ * Implements hook_civicrm_tokens().
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_tokens/
+ */
+function sqltasks_civicrm_tokens(&$tokens) {
+  $tokens['sqltasks'] = array(
+    'sqltasks.downloadURL' => ts("SQL Tasks: csv download URL"),
+  );
+}
+
+/**
+ * Implements hook_civicrm_tokenValues().
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_tokenValues/
+ */
+function sqltasks_civicrm_tokenValues(&$values, $cids, $job = NULL, $tokens = array(), $context = NULL) {
+  if (!empty($tokens['sqltasks'])) {
+    if ($tokens['sqltasks']['downloadURL']) {
+      $downloadURL = CRM_Core_Session::singleton()->get('sqltasks.downloadURL');
+      foreach ($cids as $cid) {
+        $values[$cid]['sqltasks.downloadURL'] = $downloadURL;
+      }
+    }
+  }
+}

--- a/templates/CRM/Sqltasks/Action/CSVExport.hlp
+++ b/templates/CRM/Sqltasks/Action/CSVExport.hlp
@@ -25,6 +25,10 @@
   <p>{ts domain="de.systopia.sqltasks"}<strong>Caution!</strong> The data will be sent unencrypted. Please do not use this option if the resulting files contains sensitive data.{/ts}</p>
 {/htxt}
 
+{htxt id='id-csv-downloadURL'}
+  <p>{ts domain="de.systopia.sqltasks"}Do not attach csv file in the email, include {literal}<code>{sqltasks.downloadURL}</code>{/literal} token in your template, and it will be replaced by an URL to click and download the file through CiviCRM authentication{/ts}</p>
+{/htxt}
+
 {htxt id='id-csv-filename'}
   <p>{ts domain="de.systopia.sqltasks"}The file name of the resulting CSV file.{/ts}</p>
   <p>{ts domain="de.systopia.sqltasks"}You can use the token {literal}<code>{xxx}</code>{/literal}, which will be replaced by a current date string. The format (i.e. the xxx) is defined <a href="https://secure.php.net/manual/en/function.date.php#refsect1-function.date-parameters">here</a>. An example would be <code>{literal}{Y-m-d}{/literal}</code>.{/ts}</p>

--- a/templates/CRM/Sqltasks/Action/CSVExport.tpl
+++ b/templates/CRM/Sqltasks/Action/CSVExport.tpl
@@ -68,6 +68,12 @@
   </div>
 
   <div class="crm-section">
+    <div class="label">{$form.csv_downloadURL.label}&nbsp;<a onclick='CRM.help("{ts domain="de.systopia.sqltasks"}DownloadURL{/ts}", {literal}{"id":"id-csv-downloadURL","file":"CRM\/Sqltasks\/Action\/CSVExport"}{/literal}); return false;' href="#" title="{ts domain="de.systopia.sqltasks"}Help{/ts}" class="helpicon">&nbsp;</a></div>
+    <div class="content">{$form.csv_downloadURL.html}</div>
+    <div class="clear"></div>
+  </div>
+
+  <div class="crm-section">
     <div class="label">{$form.csv_email_template.label}</div>
     <div class="content">{$form.csv_email_template.html}</div>
     <div class="clear"></div>


### PR DESCRIPTION
Even if the csv file is too big or for security reasons, sometimes is not a good idea to attach a csv file with raw information from CiviCRM DB.
This PR adds a setting to allows a new token in the template email, that will be replaced by an URL to click and download the csv/zip file, through CiviCRM authentication 