### PR TITLE
RM2380 Fix corruption of sql order task if used parallel by multiple …

### DIFF
--- a/CRM/Sqltasks/Task.php
+++ b/CRM/Sqltasks/Task.php
@@ -333,21 +333,21 @@ class CRM_Sqltasks_Task {
    * Get a list of all tasks
    */
   public static function getAllTasks() {
-    return self::getTasks('SELECT * FROM civicrm_sqltasks ORDER BY weight ASC');
+    return self::getTasks('SELECT * FROM civicrm_sqltasks ORDER BY weight ASC, id ASC');
   }
 
   /**
    * Get a list of tasks ready for execution
    */
   public static function getExecutionTaskList() {
-    return self::getTasks('SELECT * FROM civicrm_sqltasks WHERE enabled=1 ORDER BY weight ASC');
+    return self::getTasks('SELECT * FROM civicrm_sqltasks WHERE enabled=1 ORDER BY weight ASC, id ASC');
   }
 
   /**
    * Get a list of tasks ready for execution
    */
   public static function getParallelExecutionTaskList() {
-    return self::getTasks('SELECT * FROM civicrm_sqltasks WHERE enabled=1 AND parallel_exec = 1 ORDER BY weight ASC');
+    return self::getTasks('SELECT * FROM civicrm_sqltasks WHERE enabled=1 AND parallel_exec = 1 ORDER BY weight ASC, id ASC');
   }
 
   /**

--- a/api/v3/Sqltask.php
+++ b/api/v3/Sqltask.php
@@ -120,7 +120,7 @@ function civicrm_api3_sqltask_sort($params) {
       $query = "UPDATE civicrm_sqltasks SET weight = %1 WHERE id = %2";
       $sqlParams = array(
         1 => array($weight, 'String'),
-        2 => array($task[0], 'Integer'));
+        2 => array($task, 'Integer'));
 
       CRM_Core_DAO::executeQuery($query, $sqlParams);
     }

--- a/api/v3/Sqltask.php
+++ b/api/v3/Sqltask.php
@@ -96,7 +96,7 @@ function civicrm_api3_sqltask_sort($params) {
     }
 
     // fetch the task sorting from database
-    $query = "SELECT id FROM civicrm_sqltasks ORDER BY weight;";
+    $query = "SELECT id FROM civicrm_sqltasks ORDER BY weight ASC, id ASC";
     $result = CRM_Core_DAO::executeQuery($query);
     $tasksorderDatabase = [];
 
@@ -111,9 +111,7 @@ function civicrm_api3_sqltask_sort($params) {
     }
 
     // check the difference between taskorder array from database and the taskorder array from the screen
-    $checkArray = array_intersect_assoc($taskScreenOrder, $tasksorderDatabase);
-
-    if (count($checkArray) != count($taskScreenOrder)) {
+    if ($taskScreenOrder != $tasksorderDatabase) {
       return civicrm_api3_create_error('Task order was modified');
     }
 

--- a/js/sortTasks.js
+++ b/js/sortTasks.js
@@ -1,4 +1,5 @@
 cj( document ).ready(function() {
+    taskScreenOrder = fetchScreenOrder();
 
     var sortable = cj( "#sortable-tasks" ).sortable({
         placeholder: "ui-state-highlight",
@@ -8,21 +9,39 @@ cj( document ).ready(function() {
         update: function (event, ui) {
             sortable.find('tr').addClass('sorting-init');
             sortable.sortable('refresh');
-            var data = cj(this).sortable( "toArray");
+            var taskOrder = cj(this).sortable( "toArray");
 
             CRM.api3('Sqltask', 'sort', {
                 "sequential": 1,
-                "data": data
-            }).done(function(result) {
-                /*
-                Do something when sorting is finished via api. (for debugging purposes.)
-                 */
-            });
-
+                "data": taskOrder,
+                "task_screen_order": taskScreenOrder
+                }).done(function(result) {
+                    if(result.is_error == 1){
+                        alert('The following error occured: ' + result.error_message);
+                        window.location.reload();
+                    }
+                    taskScreenOrder = fetchScreenOrder();
+                }).fail(function(result) {
+                    console.log('fail: ' + result);
+                });
         }
     });
+
     sortable.find('tr').one('mouseenter', function() {
         cj(this).addClass('sorting-init');
         sortable.sortable('refresh');
     });
+
+    function fetchScreenOrder(){
+        // fetch the taskorder from the screen before it is changed
+        var taskScreenOrder = [];
+        
+        cj('tr').each(function(){
+            var id = cj(this).attr('id');
+            // console.log('id' + id);
+            if(id) taskScreenOrder.push(id);
+        });
+
+        return taskScreenOrder;
+    }
 });


### PR DESCRIPTION
If two users at the same time were changing the order of sql-tasks the second user would overwrite the changes made by the first sort. To fix that I take the screen order of the task in the clients browser and compare that on the server with the order in the database. If there is a mismatch, the browser reloads the page and the taskorder is reset to the actual order in the database. So the user can start sorting again.