### PR TITLE
Add unit tests

### DIFF
--- a/CRM/Sqltasks/Action.php
+++ b/CRM/Sqltasks/Action.php
@@ -185,7 +185,7 @@ abstract class CRM_Sqltasks_Action {
     // just compile list manually (for now)
 
     // add Segmentation Extension tasks (de.systopia.segmentation)
-    if (function_exists('segmentation_civicrm_install')) {
+    if (CRM_Sqltasks_Utils::isSegmentationInstalled()) {
       // this should run before CreateActivity and APICall because those tasks
       // might depend on segmentation data being available
       $actions[] = new CRM_Sqltasks_Action_SegmentationAssign($task);
@@ -196,7 +196,7 @@ abstract class CRM_Sqltasks_Action {
     $actions[] = new CRM_Sqltasks_Action_SyncTag($task);
     $actions[] = new CRM_Sqltasks_Action_SyncGroup($task);
 
-    if (function_exists('segmentation_civicrm_install')) {
+    if (CRM_Sqltasks_Utils::isSegmentationInstalled()) {
       $actions[] = new CRM_Sqltasks_Action_SegmentationExport($task);
     }
     $actions[] = new CRM_Sqltasks_Action_ResultHandler($task, 'success', E::ts('Success Handler'));

--- a/CRM/Sqltasks/Action/CreateActivity.php
+++ b/CRM/Sqltasks/Action/CreateActivity.php
@@ -242,7 +242,7 @@ class CRM_Sqltasks_Action_CreateActivity extends CRM_Sqltasks_Action_ContactSet 
           FROM `{$contact_table}`
           WHERE contact_id IS NOT NULL {$excludeSql});");
 
-      if (class_exists('CRM_Segmentation_Logic')) {
+      if (CRM_Sqltasks_Utils::isSegmentationInstalled()) {
         CRM_Segmentation_Logic::addSegmentForMassActivity($activity['id'], $this->getConfigValue('campaign_id'));
       }
     }
@@ -392,7 +392,7 @@ class CRM_Sqltasks_Action_CreateActivity extends CRM_Sqltasks_Action_ContactSet 
       $link->activity_id    = (int) $activity->id;
       $link->record_type_id = 3;
       $link->save();
-      if (class_exists('CRM_Segmentation_Logic')) {
+      if (CRM_Sqltasks_Utils::isSegmentationInstalled()) {
         CRM_Segmentation_Logic::addSegmentForActivityContact(
           $link->activity_id, $link->contact_id
         );
@@ -433,4 +433,5 @@ class CRM_Sqltasks_Action_CreateActivity extends CRM_Sqltasks_Action_ContactSet 
 
     return date('YmdHis', strtotime($string));
   }
+
 }

--- a/CRM/Sqltasks/Task.php
+++ b/CRM/Sqltasks/Task.php
@@ -219,6 +219,9 @@ class CRM_Sqltasks_Task {
     // error_log("STORE QUERY: " . $sql);
     // error_log("STORE PARAM: " . json_encode($params));
     CRM_Core_DAO::executeQuery($sql, $params);
+    if (empty($this->task_id)) {
+      $this->task_id = CRM_Core_DAO::singleValueQuery('SELECT LAST_INSERT_ID()');
+    }
   }
 
 

--- a/CRM/Sqltasks/Utils.php
+++ b/CRM/Sqltasks/Utils.php
@@ -1,0 +1,15 @@
+<?php
+
+/**
+ * Utility functions
+ */
+class CRM_Sqltasks_Utils {
+
+  public static function isSegmentationInstalled() {
+    return civicrm_api3('Extension', 'getcount', [
+      'full_name' => 'de.systopia.segmentation',
+      'status'    => 'installed',
+    ]) == 1;
+  }
+
+}

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<phpunit backupGlobals="false" backupStaticAttributes="false" colors="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" stopOnFailure="false" syntaxCheck="false" bootstrap="tests/phpunit/bootstrap.php">
+  <testsuites>
+    <testsuite name="My Test Suite">
+      <directory>./tests/phpunit</directory>
+    </testsuite>
+  </testsuites>
+  <filter>
+    <whitelist>
+      <directory suffix=".php">./</directory>
+    </whitelist>
+  </filter>
+  <listeners>
+    <listener class="Civi\Test\CiviTestListener">
+      <arguments/>
+    </listener>
+  </listeners>
+</phpunit>

--- a/tests/fixtures/csvexport.csv
+++ b/tests/fixtures/csvexport.csv
@@ -1,0 +1,2 @@
+contact_email;is_primary
+john.doe@example.com;1

--- a/tests/phpunit/CRM/Sqltasks/Action/APICallTest.php
+++ b/tests/phpunit/CRM/Sqltasks/Action/APICallTest.php
@@ -1,0 +1,66 @@
+<?php
+
+/**
+ * Test APICall Action
+ *
+ * @group headless
+ */
+class CRM_Sqltasks_Action_APICallTest extends CRM_Sqltasks_Action_AbstractActionTest {
+
+  public function testAPICall() {
+    $data = [
+      'main_sql'       => "DROP TABLE IF EXISTS tmp_test_action_apicall;
+                           CREATE TABLE tmp_test_action_apicall AS " . self::TEST_CONTACT_SQL,
+      'post_sql'       => 'DROP TABLE IF EXISTS tmp_test_action_apicall;',
+      'api_enabled'    => '1',
+      'api_table'      => 'tmp_test_action_apicall',
+      'api_entity'     => 'Phone',
+      'api_action'     => 'create',
+      'api_parameters' => "contact_id={contact_id}\r\nphone=1800testAPICall",
+    ];
+    $this->createAndExecuteTask($data);
+
+    $this->assertLogContains('1 API call(s) successfull.', '1 API call should have succeeded');
+    $this->assertLogContains("Action 'API Call' executed in", 'API call action should have succeeded');
+    $phoneCount = $this->callApiSuccess('Phone', 'getcount', [
+      'contact_id' => $this->contactId,
+      'phone'      => '1800testAPICall',
+    ]);
+    $this->assertEquals(1, $phoneCount, 'Phone should have been added to contact');
+  }
+
+  public function testExclude() {
+    $contactIdExcluded = $this->callApiSuccess('Contact', 'create', [
+      'contact_type' => 'Individual',
+      'email'        => 'jane.doe@example.com',
+    ])['id'];
+    $data = [
+      'main_sql'       => "DROP TABLE IF EXISTS tmp_test_action_apicall;
+                           CREATE TABLE tmp_test_action_apicall (contact_id INT(10), exclude BOOL, phone varchar(255));
+                           INSERT INTO tmp_test_action_apicall SELECT contact_id, 0 as exclude, '1800testInclude' as phone FROM civicrm_email WHERE email='john.doe@example.com';
+                           INSERT INTO tmp_test_action_apicall SELECT contact_id, 1 as exclude, '1800testExclude' as phone FROM civicrm_email WHERE email='jane.doe@example.com'",
+      'post_sql'       => 'DROP TABLE IF EXISTS tmp_test_action_apicall;',
+      'api_enabled'    => '1',
+      'api_table'      => 'tmp_test_action_apicall',
+      'api_entity'     => 'Phone',
+      'api_action'     => 'create',
+      'api_parameters' => "contact_id={contact_id}\r\nphone={phone}",
+    ];
+    $this->createAndExecuteTask($data);
+
+    $this->assertLogContains('Column "exclude" exists, might skip some rows', '"exclude" column should have been detected');
+    $this->assertLogContains('1 API call(s) successfull.', '1 API call should have succeeded');
+    $this->assertLogContains("Action 'API Call' executed in", 'API call action should have succeeded');
+    $phoneCount = $this->callApiSuccess('Phone', 'getcount', [
+      'contact_id' => $this->contactId,
+      'phone'      => '1800testInclude',
+    ]);
+    $this->assertEquals(1, $phoneCount, 'Phone should have been added to contact');
+    $phoneCountExclude = $this->callApiSuccess('Phone', 'getcount', [
+      'contact_id' => $contactIdExcluded,
+      'phone'      => '1800testExclude',
+    ]);
+    $this->assertEquals(0, $phoneCountExclude, 'Excluded phone should not have been added to contact');
+  }
+
+}

--- a/tests/phpunit/CRM/Sqltasks/Action/AbstractActionTest.php
+++ b/tests/phpunit/CRM/Sqltasks/Action/AbstractActionTest.php
@@ -1,0 +1,58 @@
+<?php
+
+use Civi\Test\Api3TestTrait;
+use Civi\Test\HeadlessInterface;
+use Civi\Test\HookInterface;
+
+/**
+ * Base class for action tests
+ *
+ * @group headless
+ */
+abstract class CRM_Sqltasks_Action_AbstractActionTest extends \PHPUnit_Framework_TestCase implements HeadlessInterface, HookInterface {
+  use Api3TestTrait;
+
+  const TEST_CONTACT_SQL = "SELECT contact_id FROM civicrm_email WHERE email = 'john.doe@example.com';";
+
+  /**
+   * @var int
+   */
+  protected $contactId;
+
+  /**
+   * @var array
+   */
+  protected $log;
+
+  public function setUpHeadless() {
+    return \Civi\Test::headless()
+      ->uninstallMe(__DIR__)
+      ->installMe(__DIR__)
+      ->apply(TRUE);
+  }
+
+  public function setUp() {
+    $this->contactId = $this->callApiSuccess('Contact', 'create', [
+      'first_name'   => 'John',
+      'last_name'    => 'Doe',
+      'contact_type' => 'Individual',
+      'email'        => 'john.doe@example.com',
+    ])['id'];
+    parent::setUp();
+  }
+
+  public function tearDown() {
+    parent::tearDown();
+  }
+
+  protected function createAndExecuteTask(array $data) {
+    $task = new CRM_Sqltasks_Task(NULL, $data);
+    $task->store();
+    $this->log = $task->execute();
+  }
+
+  protected function assertLogContains($expected, $message) {
+    $this->assertContains($expected, implode("\n", $this->log), $message);
+  }
+
+}

--- a/tests/phpunit/CRM/Sqltasks/Action/CSVExportTest.php
+++ b/tests/phpunit/CRM/Sqltasks/Action/CSVExportTest.php
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * Test CSVExport Action
+ *
+ * @group headless
+ */
+class CRM_Sqltasks_Action_CSVExportTest extends CRM_Sqltasks_Action_AbstractActionTest {
+
+  public function testFileExport() {
+    $tmp = tempnam(sys_get_temp_dir(), 'csv');
+    $data = [
+      'main_sql'           => "DROP TABLE IF EXISTS tmp_test_action_csvexport;
+                               CREATE TABLE tmp_test_action_csvexport AS SELECT email, is_primary FROM civicrm_email WHERE email='john.doe@example.com';",
+      'post_sql'           => 'DROP TABLE IF EXISTS tmp_test_action_csvexport;',
+      'csv_enabled'        => '1',
+      'csv_table'          => 'tmp_test_action_csvexport',
+      'csv_encoding'       => 'UTF-8',
+      'csv_delimiter'      => ';',
+      'csv_headers'        => "contact_email=email\r\nis_primary=is_primary",
+      'csv_filename'       => basename($tmp),
+      'csv_path'           => dirname($tmp),
+      'csv_email'          => '',
+      'csv_email_template' => '1',
+      'csv_upload'         => '',
+    ];
+    $this->createAndExecuteTask($data);
+
+    $this->assertLogContains('Written 1 records to', 'Records should have been written to CSV');
+    $this->assertLogContains("Action 'CSV Export' executed in", 'CSV Export action should have succeeded');
+    $this->assertFileEquals(__DIR__ . '/../../../../fixtures/csvexport.csv', $tmp);
+  }
+
+}

--- a/tests/phpunit/CRM/Sqltasks/Action/CreateActivityTest.php
+++ b/tests/phpunit/CRM/Sqltasks/Action/CreateActivityTest.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * Test CreateActivity Action
+ *
+ * @group headless
+ */
+class CRM_Sqltasks_Action_CreateActivityTest extends CRM_Sqltasks_Action_AbstractActionTest {
+
+  public function testCreateActivity() {
+    $data = [
+      'main_sql'                    => "DROP TABLE IF EXISTS tmp_test_action_createactivity;
+                                        CREATE TABLE tmp_test_action_createactivity AS " . self::TEST_CONTACT_SQL,
+      'post_sql'                    => 'DROP TABLE IF EXISTS tmp_test_action_createactivity',
+      'activity_enabled'            => '1',
+      'activity_contact_table'      => 'tmp_test_action_createactivity',
+      'activity_activity_type_id'   => '3',
+      'activity_status_id'          => '2',
+      'activity_subject'            => 'testCreateActivity',
+      'activity_details'            => '',
+      'activity_activity_date_time' => '',
+      'activity_campaign_id'        => '0',
+      'activity_source_contact_id'  => '1',
+      'activity_assigned_to'        => '',
+    ];
+    $this->createAndExecuteTask($data);
+
+    $this->assertLogContains("Action 'Create Activity' executed in", 'Create Activity action should have succeeded');
+    $activityCount = $this->callApiSuccess('Phone', 'getcount', [
+      'target_contact_id'          => $this->contactId,
+      'subject'                    => 'testCreateActivity',
+      'activity_status_id'         => '2',
+      'activity_source_contact_id' => '1',
+      'activity_activity_type_id'  => '3',
+    ]);
+    $this->assertEquals(1, $activityCount, 'Activity should have been added');
+  }
+
+}

--- a/tests/phpunit/CRM/Sqltasks/Action/ResultHandlerTest.php
+++ b/tests/phpunit/CRM/Sqltasks/Action/ResultHandlerTest.php
@@ -1,0 +1,71 @@
+<?php
+
+/**
+ * Test ResultHandler Action
+ *
+ * @group headless
+ */
+class CRM_Sqltasks_Action_ResultHandlerTest extends CRM_Sqltasks_Action_AbstractActionTest {
+
+  public function testSuccessHandler() {
+    $mailUtils = new CiviMailUtils($this, TRUE);
+    $data = [
+      'main_sql'                    => "DROP TABLE IF EXISTS tmp_test_action_successhandler;
+                                        CREATE TABLE tmp_test_action_successhandler AS " . self::TEST_CONTACT_SQL,
+      'post_sql'                    => 'DROP TABLE IF EXISTS tmp_test_action_successhandler;',
+      'activity_enabled'            => '1',
+      'activity_contact_table'      => 'tmp_test_action_successhandler',
+      'activity_activity_type_id'   => '3',
+      'activity_status_id'          => '2',
+      'activity_subject'            => 'testSuccessHandler',
+      'activity_details'            => '',
+      'activity_activity_date_time' => '',
+      'activity_campaign_id'        => '0',
+      'activity_source_contact_id'  => '1',
+      'activity_assigned_to'        => '',
+      'success_enabled'             => '1',
+      'success_table'               => '',
+      'success_email'               => 'successhandler@example.com',
+      'success_email_template'      => '1',
+    ];
+    $this->createAndExecuteTask($data);
+
+    $this->assertLogContains("Action 'Create Activity' executed in", 'Create Activity action should have succeeded');
+    $mailUtils->checkMailLog([
+      'successhandler@example.com',
+    ]);
+    $mailUtils->stop();
+  }
+
+  public function testErrorHandler() {
+    $mailUtils = new CiviMailUtils($this, TRUE);
+    // contains invalid activity_activity_type_id, should cause error
+    $data = [
+      'main_sql'                    => "DROP TABLE IF EXISTS tmp_test_action_errorhandler;
+                                        CREATE TABLE tmp_test_action_errorhandler AS SELECT contact_id FROM civicrm_email WHERE email='john.doe@example.com';",
+      'post_sql'                    => 'DROP TABLE IF EXISTS tmp_test_action_errorhandler;',
+      'activity_enabled'            => '1',
+      'activity_contact_table'      => 'tmp_test_action_errorhandler',
+      'activity_activity_type_id'   => '999999',
+      'activity_status_id'          => '2',
+      'activity_subject'            => 'testErrorHandler',
+      'activity_details'            => '',
+      'activity_activity_date_time' => '',
+      'activity_campaign_id'        => '0',
+      'activity_source_contact_id'  => '1',
+      'activity_assigned_to'        => '',
+      'error_enabled'               => '1',
+      'error_table'                 => '',
+      'error_email'                 => 'errorhandler@example.com',
+      'error_email_template'        => '1',
+    ];
+    $this->createAndExecuteTask($data);
+
+    $this->assertLogContains("Error in action 'Create Activity'", 'Create Activity action should have failed');
+    $mailUtils->checkMailLog([
+      'errorhandler@example.com',
+    ]);
+    $mailUtils->stop();
+  }
+
+}

--- a/tests/phpunit/CRM/Sqltasks/Action/SegmentationAssignTest.php
+++ b/tests/phpunit/CRM/Sqltasks/Action/SegmentationAssignTest.php
@@ -1,0 +1,67 @@
+<?php
+
+/**
+ * Test SegmentationAssign Action, requires de.systopia.segmentation
+ *
+ * @group headless
+ */
+class CRM_Sqltasks_Action_SegmentationAssignTest extends CRM_Sqltasks_Action_AbstractActionTest {
+
+  private $segmentationPresent;
+
+  public function setUpHeadless() {
+    $test = \Civi\Test::headless()
+      ->uninstallMe(__DIR__)
+      ->installMe(__DIR__);
+    $this->segmentationPresent = $this->callApiSuccess('Extension', 'getcount', [
+      'full_name' => 'de.systopia.segmentation',
+    ]);
+    if ($this->segmentationPresent) {
+      $test->uninstall('de.systopia.segmentation');
+      $test->install('de.systopia.segmentation');
+    }
+    return $test->apply(TRUE);
+  }
+
+  public function testSegmentationAssign() {
+    if (!$this->segmentationPresent) {
+      $this->markTestSkipped(
+        'The de.systopia.segmentation extension is not available.'
+      );
+    }
+    $campaignId = $this->callApiSuccess('Campaign', 'create', array(
+      'sequential' => 1,
+      'name'       => 'testCampaign',
+      'title'      => 'testCampaign',
+    ))['id'];
+    $data = [
+      'main_sql'                                => "DROP TABLE IF EXISTS tmp_test_action_segmentationassign;
+                                                    CREATE TABLE tmp_test_action_segmentationassign AS " . self::TEST_CONTACT_SQL,
+      'post_sql'                                => 'DROP TABLE IF EXISTS tmp_test_action_segmentationassign;',
+      'segmentation_assign_enabled'             => '1',
+      'segmentation_assign_table'               => 'tmp_test_action_segmentationassign',
+      'segmentation_assign_campaign_id'         => $campaignId,
+      'segmentation_assign_segment_name'        => 'testSegmentationAssign',
+      'segmentation_assign_start'               => 'leave',
+      'segmentation_assign_segment_order'       => '',
+      'segmentation_assign_segment_order_table' => '',
+    ];
+    $this->createAndExecuteTask($data);
+
+    $this->assertLogContains('Resolved 1 segment(s).', 'Should have resolved one segment');
+    $this->assertLogContains("Assigned 1 new contacts to segment 'testSegmentationAssign'.", 'Should have assigned one contact to segment "testSegmentationAssign"');
+    $this->assertLogContains("Action 'Assign to Campaign (Segmentation)' executed in", 'Assign to Campaign action should have succeeded');
+    $this->assertEquals(
+      1,
+      CRM_Core_DAO::singleValueQuery(
+        "SELECT COUNT(*) FROM civicrm_segmentation WHERE campaign_id = %0 AND entity_id = %1",
+        [
+          [$campaignId, 'Integer'],
+          [$this->contactId, 'Integer'],
+        ]
+      ),
+      'Should have added contact to segment'
+    );
+  }
+
+}

--- a/tests/phpunit/CRM/Sqltasks/Action/SegmentationExportTest.php
+++ b/tests/phpunit/CRM/Sqltasks/Action/SegmentationExportTest.php
@@ -1,0 +1,81 @@
+<?php
+
+/**
+ * Test SegmentationExport Action, requires de.systopia.segmentation
+ *
+ * @group headless
+ */
+class CRM_Sqltasks_Action_SegmentationExportTest extends CRM_Sqltasks_Action_AbstractActionTest {
+
+  private $segmentationPresent;
+
+  public function setUpHeadless() {
+    $test = \Civi\Test::headless()
+      ->uninstallMe(__DIR__)
+      ->installMe(__DIR__);
+    $this->segmentationPresent = $this->callApiSuccess('Extension', 'getcount', [
+      'full_name' => 'de.systopia.segmentation',
+    ]);
+    if ($this->segmentationPresent) {
+      $test->uninstall('de.systopia.segmentation');
+      $test->install('de.systopia.segmentation');
+    }
+    return $test->apply(TRUE);
+  }
+
+  public function testSegmentationExport() {
+    if (!$this->segmentationPresent) {
+      $this->markTestSkipped(
+        'The de.systopia.segmentation extension is not available.'
+      );
+    }
+    $segmentId = $this->callApiSuccess('Segmentation', 'getsegmentid', [
+      'name' => 'testSegmentationExport',
+    ])['id'];
+    $campaignId = $this->callApiSuccess('Campaign', 'create', array(
+      'sequential' => 1,
+      'name'       => 'testSegmentationExport',
+      'title'      => 'testSegmentationExport',
+    ))['id'];
+    $tmp = tempnam(sys_get_temp_dir(), 'seg');
+    $data = [
+      'main_sql'                                => "DROP TABLE IF EXISTS tmp_test_action_segmentationexport;
+                                                    CREATE TABLE tmp_test_action_segmentationexport AS " . self::TEST_CONTACT_SQL,
+      'post_sql'                                => 'DROP TABLE IF EXISTS tmp_test_action_segmentationexport;',
+      'segmentation_assign_enabled'             => '1',
+      'segmentation_assign_table'               => 'tmp_test_action_segmentationexport',
+      'segmentation_assign_campaign_id'         => $campaignId,
+      'segmentation_assign_segment_name'        => 'testSegmentationExport',
+      'segmentation_assign_start'               => 'leave',
+      'segmentation_assign_segment_order'       => '',
+      'segmentation_assign_segment_order_table' => '',
+      'segmentation_export_enabled'             => '1',
+      'segmentation_export_campaign_id'         => $campaignId,
+      'segmentation_export_segments'            => [$segmentId],
+      'segmentation_export_exporter'            => [2],
+      'segmentation_export_date_from'           => '',
+      'segmentation_export_date_to'             => '',
+      'segmentation_export_filename'            => basename($tmp),
+      'segmentation_export_path'                => dirname($tmp),
+      'segmentation_export_email'               => '',
+      'segmentation_export_email_template'      => '1',
+      'segmentation_export_upload'              => '',
+    ];
+    $this->createAndExecuteTask($data);
+
+    $this->assertLogContains("Exporter 'Selektion (Excel)' to file", 'Should have exported file');
+    $this->assertLogContains('Zipped file into', 'Should have zipped file');
+    $this->assertLogContains("Action 'Segmentation Export' executed in", 'Segmentation Export action should have succeeded');
+    $zip = new ZipArchive();
+    $zip->open($tmp);
+    $this->assertContains(
+      'contact_id;titel;anrede;vorname;nachname;geburtsdatum;strasse;plz;ort;land;zielgruppe ID;zielgruppe;telefon;mobilnr;email;paket;textbaustein',
+      $zip->getFromIndex(0)
+    );
+    $this->assertContains(
+      "{$this->contactId};;An;John;Doe;;;;;;{$segmentId};testSegmentationExport;;;john.doe@example.com;;",
+      $zip->getFromIndex(0)
+    );
+  }
+
+}

--- a/tests/phpunit/CRM/Sqltasks/Action/SyncGroupTest.php
+++ b/tests/phpunit/CRM/Sqltasks/Action/SyncGroupTest.php
@@ -1,0 +1,52 @@
+<?php
+
+/**
+ * Test SyncGroup Action
+ *
+ * @group headless
+ */
+class CRM_Sqltasks_Action_SyncGroupTest extends CRM_Sqltasks_Action_AbstractActionTest {
+
+  public function testSyncGroup() {
+    $groupId = $this->callApiSuccess('Group', 'create', array(
+      'sequential' => 1,
+      'name' => 'testSyncGroup',
+      'title' => 'testSyncGroup',
+    ))['id'];
+    $data = [
+      'main_sql'            => "DROP TABLE IF EXISTS tmp_test_action_syncgroup;
+                                CREATE TABLE tmp_test_action_syncgroup AS " . self::TEST_CONTACT_SQL,
+      'post_sql'            => 'DROP TABLE IF EXISTS tmp_test_action_syncgroup;',
+      'group_enabled'       => '1',
+      'group_contact_table' => 'tmp_test_action_syncgroup',
+      'group_group_id'      => $groupId,
+    ];
+    $this->createAndExecuteTask($data);
+
+    $this->assertLogContains("Action 'Synchronise Group' executed in", 'Synchronize Group action should have succeeded');
+    $groupContactCount = $this->callApiSuccess('GroupContact', 'getcount', [
+      'contact_id' => $this->contactId,
+      'group_id'   => $groupId,
+      'status'     => 'Added',
+    ]);
+    $this->assertEquals(1, $groupContactCount, 'Contact should have been added to group');
+    $totalGroupContactCount = $this->callApiSuccess('GroupContact', 'getcount', [
+      'group_id' => $groupId,
+      'status'   => 'Added',
+    ]);
+    $this->assertEquals(1, $totalGroupContactCount, 'Should have added one contact to group');
+    // there's no API for civicrm_subscription_history, using SQL
+    $this->assertEquals(
+      1,
+      CRM_Core_DAO::singleValueQuery(
+        "SELECT COUNT(*) FROM civicrm_subscription_history WHERE group_id = %0 AND status = 'Added' AND contact_id = %1",
+        [
+          [$groupId, 'Integer'],
+          [$this->contactId, 'Integer'],
+        ]
+      ),
+      'Should have created subscription history'
+    );
+  }
+
+}

--- a/tests/phpunit/CRM/Sqltasks/Action/SyncTagTest.php
+++ b/tests/phpunit/CRM/Sqltasks/Action/SyncTagTest.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * Test SyncTag Action
+ *
+ * @group headless
+ */
+class CRM_Sqltasks_Action_SyncTagTest extends CRM_Sqltasks_Action_AbstractActionTest {
+
+  public function testSyncTag() {
+    $tagId = $this->callApiSuccess('Tag', 'create', [
+      'name'     => 'test',
+      'used_for' => 'Contacts',
+    ])['id'];
+    $data = [
+      'main_sql'          => "DROP TABLE IF EXISTS tmp_test_action_synctag;
+                              CREATE TABLE tmp_test_action_synctag AS " . self::TEST_CONTACT_SQL,
+      'post_sql'          => 'DROP TABLE IF EXISTS tmp_test_action_synctag;',
+      'tag_enabled'       => '1',
+      'tag_contact_table' => 'tmp_test_action_synctag',
+      'tag_tag_id'        => $tagId,
+      'tag_entity_table'  => 'civicrm_contact',
+    ];
+    $this->createAndExecuteTask($data);
+
+    $this->assertLogContains("Action 'Synchronise Tag' executed in", 'Synchronize Tag action should have succeeded');
+    $entityTagCount = $this->callApiSuccess('EntityTag', 'getcount', [
+      'entity_table' => 'civicrm_contact',
+      'entity_id'    => $this->contactId,
+      'tag_id'       => $tagId,
+    ]);
+    $this->assertEquals(1, $entityTagCount, 'Contact should have been tagged');
+    $totalEntityTagCount = $this->callApiSuccess('EntityTag', 'getcount', [
+      'entity_table' => 'civicrm_contact',
+      'tag_id'       => $tagId,
+    ]);
+    $this->assertEquals(1, $totalEntityTagCount, 'Should have tagged one contact');
+  }
+
+}

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -1,0 +1,63 @@
+<?php
+
+ini_set('memory_limit', '2G');
+ini_set('safe_mode', 0);
+// phpcs:ignore
+eval(cv('php:boot --level=classloader', 'phpcode'));
+
+// Allow autoloading of PHPUnit helper classes in this extension.
+$loader = new \Composer\Autoload\ClassLoader();
+$loader->add('CRM_', __DIR__);
+$loader->add('Civi\\', __DIR__);
+$loader->add('api_', __DIR__);
+$loader->add('api\\', __DIR__);
+$loader->register();
+
+/**
+ * Call the "cv" command.
+ *
+ * @param string $cmd
+ *   The rest of the command to send.
+ * @param string $decode
+ *   Ex: 'json' or 'phpcode'.
+ * @return string
+ *   Response output (if the command executed normally).
+ * @throws \RuntimeException
+ *   If the command terminates abnormally.
+ */
+function cv($cmd, $decode = 'json') {
+  $cmd = 'cv ' . $cmd;
+  $descriptorSpec = array(0 => array("pipe", "r"), 1 => array("pipe", "w"), 2 => STDERR);
+  $oldOutput = getenv('CV_OUTPUT');
+  putenv("CV_OUTPUT=json");
+
+  // Execute `cv` in the original folder. This is a work-around for
+  // phpunit/codeception, which seem to manipulate PWD.
+  $cmd = sprintf('cd %s; %s', escapeshellarg(getenv('PWD')), $cmd);
+
+  $process = proc_open($cmd, $descriptorSpec, $pipes, __DIR__);
+  putenv("CV_OUTPUT=$oldOutput");
+  fclose($pipes[0]);
+  $result = stream_get_contents($pipes[1]);
+  fclose($pipes[1]);
+  if (proc_close($process) !== 0) {
+    throw new RuntimeException("Command failed ($cmd):\n$result");
+  }
+  switch ($decode) {
+    case 'raw':
+      return $result;
+
+    case 'phpcode':
+      // If the last output is /*PHPCODE*/, then we managed to complete execution.
+      if (substr(trim($result), 0, 12) !== "/*BEGINPHP*/" || substr(trim($result), -10) !== "/*ENDPHP*/") {
+        throw new \RuntimeException("Command failed ($cmd):\n$result");
+      }
+      return $result;
+
+    case 'json':
+      return json_decode($result, 1);
+
+    default:
+      throw new RuntimeException("Bad decoder format ($decode)");
+  }
+}


### PR DESCRIPTION
This adds basic unit tests for existing SQL task actions. This is in preparation for changes to the configuration format to allow actions to be used more flexibly (i.e. using the same action multiple times within the same task, reordering actions). Since this will require major changes, we want to make sure to not break existing functionality.