### PR TITLE
set abosolute url for download_link

### DIFF
--- a/CRM/Sqltasks/Task.php
+++ b/CRM/Sqltasks/Task.php
@@ -449,7 +449,7 @@ class CRM_Sqltasks_Task {
         'offer_link'    => $download_link,
         'as_attachment' => $attachment,
         'file_id'       => $file['id'],
-        'download_link' => CRM_Utils_System::url("civicrm/file", "reset=1&id={$file['id']}&filename={$base_name}&mime-type={$mime_type}"),
+        'download_link' => CRM_Utils_System::url("civicrm/file", "reset=1&id={$file['id']}&filename={$base_name}&mime-type={$mime_type}", TRUE),
     ];
     self::$files[] = $file_entry;
     $this->log("Published file '$filename' with URL {$file_entry['download_link']}");


### PR DESCRIPTION
When using token `{sqltasks.downloadURL}` in email templates, the download link url must be absolute to access the file when clicking. This work as well when downloading it from CiviCRM UI