### PR TITLE
check if sqltasks tokens are included to execute code

### DIFF
--- a/sqltasks.php
+++ b/sqltasks.php
@@ -209,7 +209,7 @@ function sqltasks_civicrm_tokens(&$tokens) {
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_tokenValues/
  */
 function sqltasks_civicrm_tokenValues(&$values, $cids, $job = NULL, $tokens = array(), $context = NULL) {
-  if (is_array($cids)) {
+  if (is_array($cids) && !empty($tokens['sqltasks'])) {
     $files     = CRM_Sqltasks_Task::getAllFiles();
     $last_file = CRM_Sqltasks_Task::getLastFile();
     foreach ($cids as $cid) {


### PR DESCRIPTION
Check if  `sqltasks` tokens are coming in `hook_civicrm_tokenValues()`, to avoid executing following code for ANY token in EVERY action involving tokens in Civi