### PR TITLE
enotice fix when no sql files are downloadable

### DIFF
--- a/sqltasks.php
+++ b/sqltasks.php
@@ -190,6 +190,9 @@ function sqltasks_civicrm_tokens(&$tokens) {
  */
 function sqltasks_civicrm_tokenValues(&$values, $cids, $job = NULL, $tokens = array(), $context = NULL) {
   $files     = CRM_Sqltasks_Task::getAllFiles();
+  if (!$files) {
+    return;
+  }
   $last_file = CRM_Sqltasks_Task::getLastFile();
   foreach ($cids as $cid) {
     $values[$cid]['sqltasks.downloadURL']   = $last_file['download_link'];


### PR DESCRIPTION
This is to prevent log noise - without this I get this notice:
```
 Notice: Trying to access array offset on value of type bool in sqltasks_civicrm_tokenValues()
```


