### PR TITLE
GP-26375 Fix email issue when sending to multiple recipients

### DIFF
--- a/CRM/Sqltasks/Action/EmailActionTrait.php
+++ b/CRM/Sqltasks/Action/EmailActionTrait.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * Trait for Action classes that send out email
+ */
+trait CRM_Sqltasks_Action_EmailActionTrait {
+
+  public function sendEmailMessage(array $params) {
+    [$domainEmailName, $domainEmailAddress] = CRM_Core_BAO_Domain::getNameAndEmail();
+
+    $templateParams = array_merge(
+      [
+        'id'        => $params['id'],
+        'from'      => "SQL Tasks <{$domainEmailAddress}>",
+        'contactId' => CRM_Core_Session::getLoggedInContactID(),
+      ],
+      $params
+    );
+    unset($templateParams['to_email']);
+    $emailDomain = CRM_Core_BAO_MailSettings::defaultDomain();
+    if (!empty($emailDomain)) {
+      $templateParams['reply_to'] = "do-not-reply@{$emailDomain}";
+    }
+
+    $to_email = $params['to_email'];
+    if (!is_array($to_email)) {
+      // assume we've received a comma-separated list of recipients
+      $to_email = explode(',', $to_email);
+    }
+
+    foreach ($to_email as $email) {
+      $email = trim($email);
+      civicrm_api3('MessageTemplate', 'send', array_merge(
+        $templateParams,
+        ['to_email' => $email],
+      ));
+      $this->log("Sent {$this->id} message to '{$email}'");
+    }
+  }
+
+}

--- a/CRM/Sqltasks/Action/SegmentationExport.php
+++ b/CRM/Sqltasks/Action/SegmentationExport.php
@@ -22,6 +22,7 @@ use CRM_Sqltasks_ExtensionUtil as E;
  * @see https://github.com/systopia/de.systopia.segmentation
  */
 class CRM_Sqltasks_Action_SegmentationExport extends CRM_Sqltasks_Action {
+  use CRM_Sqltasks_Action_EmailActionTrait;
 
   /**
    * Get identifier string
@@ -297,27 +298,18 @@ class CRM_Sqltasks_Action_SegmentationExport extends CRM_Sqltasks_Action {
     $config_email = $this->getConfigValue('email');
     $config_email_template = $this->getConfigValue('email_template');
     if (!empty($config_email) && !empty($config_email_template)) {
-      // add all the variables
-      $email_list = $this->getConfigValue('email');
-      list($domainEmailName, $domainEmailAddress) = CRM_Core_BAO_Domain::getNameAndEmail();
-
-      $attachment  = array('fullPath'  => $filepath,
-                           'mime_type' => 'application/zip',
-                           'cleanName' => basename($filepath));
-      // and send the template via email
-      $email = array(
+      $attachment  = [
+        'fullPath'  => $filepath,
+        'mime_type' => 'application/zip',
+        'cleanName' => basename($filepath)
+      ];
+      // send the template via email
+      $email = [
         'id'              => $this->getConfigValue('email_template'),
-        // 'to_name'         => $this->getConfigValue('email'),
         'to_email'        => $this->getConfigValue('email'),
-        'from'            => "SQL Tasks <{$domainEmailAddress}>",
-        'attachments'     => array($attachment),
-        );
-      $emailDomain = CRM_Core_BAO_MailSettings::defaultDomain();
-      if (!empty($emailDomain)) {
-        $email['reply_to'] = "do-not-reply@{$emailDomain}";
-      }
-      civicrm_api3('MessageTemplate', 'send', $email);
-      $this->log("Sent file to '{$email_list}'");
+        'attachments'     => [$attachment],
+      ];
+      $this->sendEmailMessage($email);
     }
 
     // PROCESS 2: UPLOAD


### PR DESCRIPTION
This fixes an issue with newer versions of Civi when sending emails to multiple recipients using a comma-separated list of email addresses.

`MessageTemplate.send` no longer accepts multiple recipients in a single call, so we call the API multiple times instead.

Shared email sending code was extracted into a trait to DRY things up a bit.