### PR TITLE
add composer.json to facilitate inclusion in Drupal 9 stack with composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,11 @@
+{
+    "name": "civicrm/sqltasks",
+    "description": "Manage recurring tasks based on SQL queries",
+    "license": "AGPL-3.0-only",
+    "authors": [
+        {
+            "name": "SYSTOPIA",
+            "email": "endres@systopia.de"
+        }
+    ]
+}


### PR DESCRIPTION
add composer.json with package name, so this extension can be easily included in main D8/D9 composer stack file.
Discussion in MM extension channel [here](https://chat.civicrm.org/civicrm/pl/kqhekzi3a3rz7bscgjemf6afjh)