### PR TITLE
fix undefined array key warnings in PHP8

### DIFF
--- a/api/v3/Sqltask/Execute.php
+++ b/api/v3/Sqltask/Execute.php
@@ -9,8 +9,8 @@
  */
 function civicrm_api3_sqltask_execute($params) {
   $exec_params = [
-    'log_to_file' => $params['log_to_file'],
-    'input_val' => $params['input_val'],
+    'log_to_file' => $params['log_to_file'] ?? NULL,
+    'input_val' => $params['input_val'] ?? NULL,
   ];
   // If task_id given run only this one task
   if (!empty($params['id'])) {

--- a/api/v3/Sqltaskfield/Getmessagetemplates.php
+++ b/api/v3/Sqltaskfield/Getmessagetemplates.php
@@ -18,7 +18,7 @@ function civicrm_api3_sqltaskfield_getmessagetemplates() {
 
   if (!empty($messageTemplate['values'])) {
     foreach ($messageTemplate['values'] as $template) {
-      $messageTemplates[$template['id']] = $template['msg_title'];
+      $messageTemplates[$template['id']] = $template['msg_title'] ?? NULL;
     }
   }
 


### PR DESCRIPTION
Just suppressing some PHP8 warnings.