### PR TITLE
Fix TypeError: Symfony\Component\DependencyInjection\Definition::addMethodCall(): Argument #3 ($returnsClone) must be of type bool, array given

### DIFF
--- a/Civi/Sqltasks/CompilerPass.php
+++ b/Civi/Sqltasks/CompilerPass.php
@@ -17,7 +17,7 @@ class CompilerPass implements CompilerPassInterface {
         'SqltasksRunSQLTask',
         'Civi\Sqltasks\Actions\RunSQLTask',
         E::ts('Run SQL Task'),
-      ], []);
+      ]);
     }
   }
 


### PR DESCRIPTION
Introduced with #122.