### PR TITLE
Ensure html attributes are escaped in templates

### DIFF
--- a/info.xml
+++ b/info.xml
@@ -14,11 +14,11 @@
     <url desc="Support">https://github.com/systopia/de.systopia.sqltasks/issues</url>
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
-  <releaseDate></releaseDate>
+  <releaseDate/>
   <version>3.0.0-dev</version>
   <develStage>dev</develStage>
   <compatibility>
-    <ver>5.45</ver>
+    <ver>5.65</ver>
   </compatibility>
   <comments>The initial development of this handy tool was funded by Greenpeace Central and Eastern Europe</comments>
   <civix>

--- a/templates/CRM/Sqltasks/Form/SqltaskSettings.tpl
+++ b/templates/CRM/Sqltasks/Form/SqltaskSettings.tpl
@@ -4,7 +4,7 @@
     <div class="sql-task__settings-buttons-wrap">
       <div class="sql-task__button-wrap">
         <a class="sql-task__button sql-task__search-button crm-form-submit default crm-button crm-hover-button"
-           href="{crmURL p='civicrm/sqltasks/manage' q='reset=1'}" title="{ts}Go to the SQL Task Manager{/ts}">
+           href="{crmURL p='civicrm/sqltasks/manage' q='reset=1'}" title="{ts escape='htmlattribute'}Go to the SQL Task Manager{/ts}">
           <span class="crm-i fa-list"></span>
           <span>{ts}Go to the SQL Task Manager{/ts}</span>
         </a>

--- a/templates/CRM/Sqltasks/Form/SqltasksExecutionList.tpl
+++ b/templates/CRM/Sqltasks/Form/SqltasksExecutionList.tpl
@@ -71,13 +71,13 @@
               </button>
 
               <a class="sql-task__search-button crm-form-submit default crm-button crm-hover-button"
-                 href="{crmURL p='civicrm/sqltasks-execution/list' q='reset=1'}" title="{ts}Clear all search criteria{/ts}">
+                 href="{crmURL p='civicrm/sqltasks-execution/list' q='reset=1'}" title="{ts escape='htmlattribute'}Clear all search criteria{/ts}">
                 <span class="ui-button-icon ui-icon fa-undo"></span>
                 <span>{ts}Reset Form{/ts}</span>
               </a>
 
               <a class="sql-task__search-button crm-form-submit default crm-button crm-hover-button"
-                 href="{crmURL p='civicrm/sqltasks/manage' q='reset=1'}" title="{ts}Go to the SQL Task Manager{/ts}">
+                 href="{crmURL p='civicrm/sqltasks/manage' q='reset=1'}" title="{ts escape='htmlattribute'}Go to the SQL Task Manager{/ts}">
                 <span class="ui-button-icon ui-icon fa-list"></span>
                 <span>{ts}Go to the SQL Task Manager{/ts}</span>
               </a>

--- a/templates/CRM/Sqltasks/Page/GlobalTokenManager.tpl
+++ b/templates/CRM/Sqltasks/Page/GlobalTokenManager.tpl
@@ -2,7 +2,7 @@
 
   <div class="sql-task__button-wrap">
     <a class="sql-task__button sql-task__search-button crm-form-submit default crm-button crm-hover-button"
-       href="{crmURL p='civicrm/sqltasks/manage' q='reset=1'}" title="{ts}Go to the SQL Task Manager{/ts}">
+       href="{crmURL p='civicrm/sqltasks/manage' q='reset=1'}" title="{ts escape='htmlattribute'}Go to the SQL Task Manager{/ts}">
       <span class="crm-i fa-list"></span>
       <span>{ts}Go to the SQL Task Manager{/ts}</span>
     </a>

--- a/templates/CRM/Sqltasks/Page/Mytasks.tpl
+++ b/templates/CRM/Sqltasks/Page/Mytasks.tpl
@@ -31,7 +31,7 @@
             <a class="button sqltask-mytask-run"
                href="#"
                id="sqltask-{$task.id}"
-               title="{ts domain="de.systopia.sqltasks" 1=$task.name}RUN %1{/ts}"
+               title="{ts escape='htmlattribute' domain="de.systopia.sqltasks" 1=$task.name}RUN %1{/ts}"
                data-task-id="{$task.id}"
                data-is-input-required="{$task.input_required}"
             >

--- a/templates/CRM/Sqltasks/Page/SqltasksExecutionView.tpl
+++ b/templates/CRM/Sqltasks/Page/SqltasksExecutionView.tpl
@@ -3,7 +3,7 @@
     <div class="sql-task__execution-logs-wrap">
       <div class="sql-task__view-logs-buttons">
         <a class="sql-task__view-logs-button crm-form-submit default crm-button crm-hover-button"
-           href="{crmURL p='civicrm/sqltasks-execution/list' q='reset=1'}" title="{ts}Go to lis{/ts}">
+           href="{crmURL p='civicrm/sqltasks-execution/list' q='reset=1'}" title="{ts escape='htmlattribute'}Go to lis{/ts}">
           <span class="ui-button-icon ui-icon fa-list"></span>
           <span class="ui-button-icon-space"> </span>
           <span>{ts}Back to list{/ts}</span>

--- a/templates/CRM/Sqltasks/Page/Templates.tpl
+++ b/templates/CRM/Sqltasks/Page/Templates.tpl
@@ -75,7 +75,7 @@
             </button>
 
             <a class="sql-task__button sql-task__search-button crm-form-submit default crm-button crm-hover-button"
-               href="{crmURL p='civicrm/sqltasks/manage' q='reset=1'}" title="{ts}Go to the SQL Task Manager{/ts}">
+               href="{crmURL p='civicrm/sqltasks/manage' q='reset=1'}" title="{ts escape='htmlattribute'}Go to the SQL Task Manager{/ts}">
               <span class="crm-i fa-list"></span>
               <span>{ts}Go to the SQL Task Manager{/ts}</span>
             </a>


### PR DESCRIPTION
This adds escape='htmlattribute' to all translations within tags, which ensures any special characters in the translated string
are properly escaped and don't break out of the quotes or cause other problems.

See https://github.com/civicrm/civicrm-core/pull/26792

Note: This requires CiviCRM 5.65 at minimum.